### PR TITLE
Improved response handling

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,5 @@
 src
+test
 tags
+.babelrc
+.gitignore

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "fabulous redux api utils",
   "main": "dist/index.js",
   "scripts": {
-    "test": "mocha ./src/test/*-test.js --compilers js:babel-register --recursive",
-    "test:watch": "mocha ./src/test/*-test.js --compilers js:babel-register --recursive --watch",
+    "test": "mocha ./test/*-test.js --compilers js:babel-register --recursive",
+    "test:watch": "mocha ./test/*-test.js --compilers js:babel-register --recursive --watch",
     "clean": "rm -rf dist/*",
     "precompile": "npm run clean",
     "compile": "babel -d dist/ src/",
@@ -24,4 +24,5 @@
     "isomorphic-fetch": "^2.2.1",
     "mocha": "^2.4.5",
     "sinon": "^1.17.4"
-  }}
+  }
+}

--- a/src/api-utils.js
+++ b/src/api-utils.js
@@ -11,17 +11,26 @@ const addParams = (endpoint, params) => {
   return `${endpoint}${params ? "?" + Object.keys(params).map(key => `${key}=${params[key]}`).join("&") : ""}`;
 };
 
+
+const responseBody = response => {
+  return response.text().then(text => {
+    try {
+      return JSON.parse(text)
+    } catch(Error) {
+      return text;
+    }
+  })
+}
+
 const makeRequest = (method) => (endpoint, { body, params } = {}) => {
   const fetchReq = buildFetchRequest({ endpoint: addParams(endpoint, params), options: { method, body } });
-  return fetch(fetchReq)
-    .then(response => response.json()
-      .then(json => {
-        if (!response.ok) {
-          return Promise.reject(json);
-        }
-        return json;
-      }));
-};
+
+  return new Promise((resolve, reject) => {
+    fetch(fetchReq).then(response => {
+      responseBody(response).then(response.ok? resolve : reject)
+    })
+  })
+}
 
 // Usage: post("/users", {body: {"name": "Peter"}, params: {"key": "value"}})
 export const get = makeRequest("GET");

--- a/test/api-utils-test.js
+++ b/test/api-utils-test.js
@@ -3,7 +3,7 @@ import fetchMock from "fetch-mock";
 
 import expect from "expect";
 import sinon from "sinon";
-import * as apiCalls from "../api-utils";
+import * as apiCalls from "../src/api-utils";
 
 describe('api calls', () => {
 


### PR DESCRIPTION
Not sure about the "magic" responseBody handling using a try/catch. Maybe we should enforce the need of json headers in the response and look for those. 

We must also check if returning an empty string as response/error is what we really want to do when the response body is empty 😆  
