### PR TITLE
Add FormData object support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ This options, for the most part adhere to the fetch Request API.
 
 ### v2.0.1
 
-* Fix headers check wehn forcing Content-Type to be case insensitive
+* Fix headers check when forcing Content-Type to be case insensitive
 
 ### v2.0.0
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To send an object as the JSON body:
 ```javascript
 import { post } from "fredux-api-utils";
 
-get("/users", { body: {name: "Peter"} })
+post("/users", { body: {name: "Peter"} })
   .then(response => console.log(response))
   .catch(error => console.log(error));
 ```
@@ -37,24 +37,42 @@ To send form data as the body:
 ```javascript
 import { post } from "fredux-api-utils";
 
-get("/users", { formData: { key1: "value1", key2: ["value2", "value3"] } })
+post("/users", { formData: { key1: "value1", key2: ["value2", "value3"] } })
   .then(response => console.log(response))
   .catch(error => console.log(error));
 ```
 
-To add some headers.
+To send form data as `FormData` object:
+
+```javascript
+import { post } from "fredux-api-utils";
+
+const formData = new FormData();
+formData.append("name", "My Name");
+formData.append("file", new Blob(["Some notes..."], { type: "text/plain" }));
+
+// If there's not a Content-Type header, will use multipart/form-data
+post("/users", { formData })
+  .then(response => console.log(response))
+  .catch(error => console.log(error));
+
+```
+
+To add some headers:
 
 
 ```javascript
 import { post } from "fredux-api-utils";
 
-get("/users", { headers: { "my-custom-header": "custom" } })
+post("/users", { headers: { "my-custom-header": "custom" } })
   .then(response => console.log(response))
   .catch(error => console.log(error));
 ```
 
-**NOTE**: when passing a `body` option `Content-Type: application/json` will always be set unless you explicitely pass
-a `Content-Type` header. The same goes with `formData` and `Content-Type: x-www-form-urlencoded`.
+**NOTE**: when passing a `body` option, `Content-Type: application/json` will always be set unless you explicitely pass
+a `Content-Type`. The same goes with `formData` and `Content-Type: x-www-form-urlencoded` unless you pass
+a `FormData` object. In this case, `Content-Type: multipart/form-data` will be set automatically as default (you
+can override it anyway).
 
 
 To set several other options just pass them:
@@ -78,7 +96,7 @@ Where `endpoint` is a string with the resource you wish to fetch and `options` i
 object containing custom settings you want to apply to the request. The possible options are:
 
 * `body`: any JSON body.
-* `formData`: any data to be passed as a x-www-form-urlencoded object
+* `formData`: any data to be passed as a `x-www-form-urlencoded` object or a `FormData` instance.
 * `params`: an object containing query params.
 * `headers`: any headers you want to add to your request.
 * `timeout`: any timeout in milliseconds. The default is `0`.

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "fabulous redux api utils",
   "main": "dist/index.js",
   "scripts": {
-    "test": "mocha ./test/*-test.js --compilers js:babel-register --recursive",
-    "test:watch": "mocha ./test/*-test.js --compilers js:babel-register --recursive --watch",
+    "test": "mocha ./test/*-test.js -r jsdom-global/register --compilers js:babel-register --recursive",
+    "test:watch": "mocha ./test/*-test.js -r jsdom-global/register --compilers js:babel-register --recursive --watch",
     "clean": "rm -rf dist/*",
     "lint": "eslint ./src ./test",
     "lint:fix": "eslint ./src ./test --fix",
@@ -26,11 +26,13 @@
     "eslint-config-prettier": "^1.6.0",
     "eslint-config-trabe": "^0.0.5",
     "eslint-plugin-prettier": "^2.0.1",
-    "expect": "^1.20.1",
-    "fetch-mock": "^4.5.0",
+    "expect": "^1.20.2",
+    "fetch-mock": "^5.12.1",
     "isomorphic-fetch": "^2.2.1",
-    "mocha": "^2.4.5",
-    "prettier": "^0.22.0",
+    "jsdom": "11.1.0",
+    "jsdom-global": "3.0.2",
+    "mocha": "^3.5.0",
+    "prettier": "^1.5.3",
     "sinon": "^1.17.4"
   },
   "eslintConfig": {

--- a/src/api-utils.js
+++ b/src/api-utils.js
@@ -1,7 +1,5 @@
 const array = a => (a instanceof Array ? a : [a]);
 
-const identity = e => e;
-
 const isFormDataObj = e => (typeof FormData !== "undefined" && e instanceof FormData);
 
 const urlParameter = (key, value) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
@@ -60,17 +58,15 @@ function buildFetchRequest(
   }
 
   if (formData) {
-    let transformData = identity;
+    options.body = formData;
 
     if (!isFormDataObj(formData)) {
-      transformData = toUrlParams;
+      options.body = toUrlParams(options.body);
 
       if (!caseInsensitiveHasKey(headers, "Content-Type")) {
         options.headers["Content-Type"] = "application/x-www-form-urlencoded";
       }
     }
-
-    options.body = transformData(formData);
   }
 
   return new Request(endpoint, options);

--- a/src/api-utils.js
+++ b/src/api-utils.js
@@ -1,4 +1,8 @@
-const array = a => a instanceof Array ? a : [a];
+const array = a => (a instanceof Array ? a : [a]);
+
+const identity = e => e;
+
+const isFormDataObj = e => (typeof FormData !== "undefined" && e instanceof FormData);
 
 const urlParameter = (key, value) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
 
@@ -56,17 +60,24 @@ function buildFetchRequest(
   }
 
   if (formData) {
-    options.body = toUrlParams(formData);
-    if (!caseInsensitiveHasKey(headers, "Content-Type")) {
-      options.headers["Content-Type"] = "application/x-www-form-urlencoded";
+    let transformData = identity;
+
+    if (!isFormDataObj(formData)) {
+      transformData = toUrlParams;
+
+      if (!caseInsensitiveHasKey(headers, "Content-Type")) {
+        options.headers["Content-Type"] = "application/x-www-form-urlencoded";
+      }
     }
+
+    options.body = transformData(formData);
   }
 
   return new Request(endpoint, options);
 }
 
 const addQuery = (endpoint, params) =>
-  !params || Object.keys(params).length === 0 ? endpoint : `${endpoint}?${toUrlParams(params)}`;
+  (!params || Object.keys(params).length === 0 ? endpoint : `${endpoint}?${toUrlParams(params)}`);
 
 const makeRequest = method =>
   (endpoint, options = {}) => {

--- a/test/api-utils-test.js
+++ b/test/api-utils-test.js
@@ -124,6 +124,27 @@ describe("body handling", () => {
     });
   });
 
+  describe("from FormData body", () => {
+    it("handles the body", () => {
+      withMockCall({}, url => {
+        const formData = new FormData();
+        formData.append("name", "Mr Potato");
+        formData.append("color", "blue")
+
+        post(url, { formData });
+
+        // mock-test returns body without processing
+        expect(lastCall().body.get("name")).toEqual("Mr Potato");
+        expect(lastCall().body.get("color")).toEqual("blue");
+      });
+    });
+
+    // TODO: Can't fully test FormData for now due to mock-test limitations... :'(
+    it("handles a file");
+    it("handles auto content-type");
+    it("respects another headers");
+  });
+
   describe("response handling", () => {
     it("returns a promise", done => {
       withMockCall({}, url => {


### PR DESCRIPTION
Add `FormData` object support (including `File` sending):

```javascript
import { post } from "fredux-api-utils";

const formData = new FormData();
formData.append("name", "My Name");
formData.append("file", new Blob(["Some notes..."], { type: "text/plain" }));

// If there's not a Content-Type header, will use multipart/form-data
post("/users", { formData })
  .then(response => console.log(response))
  .catch(error => console.log(error));
```